### PR TITLE
Add optional argument to neglect `domain_local_await`

### DIFF
--- a/lib/multicore_bench.mli
+++ b/lib/multicore_bench.mli
@@ -5,6 +5,7 @@ module Times : sig
     budgetf:float ->
     n_domains:int ->
     ?ensure_multi_domain:bool ->
+    ?domain_local_await:[< `Busy_wait | `Neglect > `Busy_wait ] ->
     ?n_warmups:int ->
     ?n_runs_min:int ->
     ?before:(unit -> unit) ->


### PR DESCRIPTION
By default, the benchmark framework replaces the blocking operations provided by `domain-local-await`, that use `Mutex` and `Condition` by default, with a busy-wait based implementation.  The reason for that is that suspending and later resuming a domain using a mutex and condition can be extremely expensive.  The cost can be 100μs or 100kns on the "fermat" machine we currently use for benchmarking multicore code, for example, which is 2 to 3 orders of magnitude more than what typical lock-free operations take.  So, when that happens in a benchmark, you are no longer measuring the lock-free algorithm and you are measuring the OS and OCaml runtime context switch cost.  The result will then be basically just noise.  Reconfiguring DLA allows to measure the cost it takes to support blocking rather than the cost of blocking itself.