### PR TITLE
Add `-debug` flag/mode to help debug benchmarks

### DIFF
--- a/lib/cmd.ml
+++ b/lib/cmd.ml
@@ -1,11 +1,15 @@
-let run ~benchmarks ?(budgetf = 0.025) ?(filters = []) ?(argv = Sys.argv)
-    ?(flush = true) () =
+let run ~benchmarks ?(budgetf = 0.025) ?(filters = []) ?(debug = false)
+    ?(argv = Sys.argv) ?(flush = true) () =
   let budgetf = ref budgetf in
   let filters = ref filters in
+  let debug = ref debug in
 
   let rec specs =
     [
       ("-budget", Arg.Set_float budgetf, "seconds\t  Budget for a benchmark");
+      ( "-debug",
+        Arg.Set debug,
+        "\t  Print progress information to help debugging" );
       ("-help", Unit help, "\t  Show this help message");
       ("--help", Unit help, "\t  Show this help message");
     ]
@@ -32,6 +36,9 @@ let run ~benchmarks ?(budgetf = 0.025) ?(filters = []) ?(argv = Sys.argv)
     invalid_arg "budgetf out of range";
 
   let run (name, fn) =
+    if !debug then
+      (* I wish there was a way to tell dune not to capture stderr. *)
+      Printf.printf "Running: %s\n%!" name;
     let metrics = fn ~budgetf in
     `Assoc [ ("name", `String name); ("metrics", `List metrics) ]
   in

--- a/lib/multicore_bench.mli
+++ b/lib/multicore_bench.mli
@@ -141,6 +141,7 @@ module Cmd : sig
     benchmarks:(string * Suite.t) list ->
     ?budgetf:float ->
     ?filters:string list ->
+    ?debug:bool ->
     ?argv:string array ->
     ?flush:bool ->
     unit ->


### PR DESCRIPTION
By default all the benchmarks are run and the results collected before any output is produced.  This can make it difficult to determine which benchmark is causing problems in case of bugs.  The `-debug` flag/mode is supposed to help debug benchmarks by printing some progress information.