### PR TITLE
Add `-brief` output mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Next release
 
+- Add `-brief` to show results in a concise human readable format (@polytypic)
 - Add support for `wrap`ping the work without timing `wrap` itself (@polytypic)
 - Add `-diff base.json` switch to diff against base results from file
   (@polytypic)

--- a/bench/dune
+++ b/bench/dune
@@ -10,6 +10,8 @@ let () =
 
 (test
  (name main)
+ (action
+  (run %{test} -brief))
  (libraries
   multicore-bench
   backoff

--- a/lib/multicore_bench.mli
+++ b/lib/multicore_bench.mli
@@ -143,12 +143,23 @@ end
 module Cmd : sig
   (** Command line interface for a benchmark executable. *)
 
+  type output =
+    [ `JSON
+      (** [`JSON] gives the JSON output for
+          {{:https://github.com/ocurrent/current-bench}current-bench}. *)
+    | `Brief  (** [`Brief] gives concise human readable output. *)
+    | `Diff of string
+      (** [`Diff "path.json"] gives concise human readable diff against results
+          stored in specified [path.json] file. *)
+    ]
+  (** Specifies the output format. *)
+
   val run :
     benchmarks:(string * Suite.t) list ->
     ?budgetf:float ->
     ?filters:string list ->
     ?debug:bool ->
-    ?diff:string ->
+    ?output:output ->
     ?argv:string array ->
     ?flush:bool ->
     unit ->
@@ -169,8 +180,7 @@ module Cmd : sig
       - [~debug]: Print progress information to help debugging.  Defaults to
         [false].
 
-      - [~diff]: Name of JSON file of results to show diff against.  Defaults to
-        [None].
+      - [~output]: Output mode.  Defaults to [`JSON].
 
       - [~argv]: Array of command line arguments.  Defaults to [Sys.argv].
 


### PR DESCRIPTION
This is useful as the output mode when running a benchmark executable as a test and the JSON output is just too much.