### PR TITLE
Fix tests to pass on FreeBSD

### DIFF
--- a/bench/bench_unix.ml
+++ b/bench/bench_unix.ml
@@ -1,18 +1,21 @@
 open Multicore_bench
 
 let run_one ~budgetf ~n_domains () =
-  let n_bytes = 65536 in
+  let block_size = 4096 in
+  let n_blocks = 16 in
 
   let init _ =
     let inn, out = Unix.pipe ~cloexec:true () in
-    (inn, out, Bytes.create 1)
+    (inn, out, Bytes.create block_size, Bytes.create 1)
   in
-  let work _ (inn, out, byte) =
-    let n = Unix.write out (Bytes.create n_bytes) 0 n_bytes in
-    assert (n = n_bytes);
-    for _ = 1 to n_bytes do
-      let n : int = Unix.read inn byte 0 1 in
-      assert (n = 1)
+  let work _ (inn, out, block, byte) =
+    for _ = 1 to n_blocks do
+      let n = Unix.write out block 0 block_size in
+      assert (n = block_size);
+      for _ = 1 to block_size do
+        let n : int = Unix.read inn byte 0 1 in
+        assert (n = 1)
+      done
     done;
     Unix.close inn;
     Unix.close out
@@ -22,8 +25,9 @@ let run_one ~budgetf ~n_domains () =
     Printf.sprintf "%d worker%s" n_domains (if n_domains = 1 then "" else "s")
   in
   Times.record ~budgetf ~n_domains ~n_warmups:1 ~n_runs_min:1 ~init ~work ()
-  |> Times.to_thruput_metrics ~n:(n_bytes * n_domains) ~singular:"blocking read"
-       ~config
+  |> Times.to_thruput_metrics
+       ~n:(block_size * n_blocks * n_domains)
+       ~singular:"blocking read" ~config
 
 let run_suite ~budgetf =
   [ 1; 2; 4 ]


### PR DESCRIPTION
It seems that writing 64kB to a pipe on FreeBSD is not a good idea.  This PR changes the `Unix` benchmark (which is for comparing with `Picos_stdio.Unix`) to instead use 4kB repeated multiple times.