### PR TITLE
Randomize the order of benchmark suites by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Next version
+
+- Randomize suites to expose variation from effects on runtime (@polytypic)
+
 ## 0.1.3
 
 - Add `Metric.make` to allow ad hoc metrics (@polytypic)

--- a/lib/multicore_bench.mli
+++ b/lib/multicore_bench.mli
@@ -180,6 +180,7 @@ module Cmd : sig
     ?output:output ->
     ?argv:string array ->
     ?flush:bool ->
+    ?randomize:bool ->
     unit ->
     unit
   (** [run ~benchmarks ()] interprets command line arguments and runs the
@@ -204,6 +205,9 @@ module Cmd : sig
 
       - [~flush]: Whether to flush the standard output after writing it.
         Defaults to [true].
+
+      - [~randomize]: Whether to randomize the order of suites or not.  Defaults
+        to [true].
 
       Command line arguments take precedence over the optional arguments.  In
       other words, you can specify the optional arguments to give defaults for


### PR DESCRIPTION
The intention behind this is to try to account for things that might put the runtime into a state where it has major effects on specific benchmarks.  After randomizing, we should see variation from run to run rather than e.g. having the potential effects only shown in specific suites.