### PR TITLE
Add a benchmark of atomic increments

### DIFF
--- a/bench/bench_incr.ml
+++ b/bench/bench_incr.ml
@@ -1,0 +1,75 @@
+open Multicore_bench
+
+let run_one ~budgetf ~n_domains ~approach () =
+  let counter = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+
+  let n_ops = 500 * Util.iter_factor / n_domains in
+
+  let n_ops_todo = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+
+  let init _ = Atomic.set n_ops_todo n_ops in
+  let work _ () =
+    match approach with
+    | `Cas ->
+        let rec work () =
+          let n = Util.alloc n_ops_todo in
+          if n <> 0 then
+            let rec loop n =
+              if 0 < n then begin
+                let v = Atomic.get counter in
+                let success = Atomic.compare_and_set counter v (v + 1) in
+                loop (n - Bool.to_int success)
+              end
+              else work ()
+            in
+            loop n
+        in
+        work ()
+    | `Cas_backoff ->
+        let rec work () =
+          let n = Util.alloc n_ops_todo in
+          if n <> 0 then
+            let rec loop backoff n =
+              if 0 < n then begin
+                let v = Atomic.get counter in
+                if Atomic.compare_and_set counter v (v + 1) then
+                  loop Backoff.default (n - 1)
+                else loop (Backoff.once backoff) n
+              end
+              else work ()
+            in
+            loop Backoff.default n
+        in
+        work ()
+    | `Incr ->
+        let rec work () =
+          let n = Util.alloc n_ops_todo in
+          if n <> 0 then
+            let rec loop n =
+              if 0 < n then begin
+                Atomic.incr counter;
+                loop (n - 1)
+              end
+              else work ()
+            in
+            loop n
+        in
+        work ()
+  in
+
+  let config =
+    Printf.sprintf "%s, %d domains"
+      (match approach with
+      | `Cas -> "CAS"
+      | `Cas_backoff -> "CAS with backoff"
+      | `Incr -> "Incr")
+      n_domains
+  in
+  Times.record ~budgetf ~n_domains ~init ~work ()
+  |> Times.to_thruput_metrics ~n:n_ops ~singular:"op" ~config
+
+let run_suite ~budgetf =
+  Util.cross [ `Cas; `Cas_backoff; `Incr ] [ 1; 2; 4; 8 ]
+  |> List.concat_map @@ fun (approach, n_domains) ->
+     if Domain.recommended_domain_count () < n_domains then []
+     else run_one ~budgetf ~n_domains ~approach ()

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -7,6 +7,7 @@ let benchmarks =
     ("Queue", Bench_queue.run_suite);
     ("Stack", Bench_stack.run_suite);
     ("Unix", Bench_unix.run_suite);
+    ("Atomic incr", Bench_incr.run_suite);
   ]
 
 let () = Multicore_bench.Cmd.run ~benchmarks ()


### PR DESCRIPTION
This adds a benchmark of incrementing a `int Atomic.t` using `Atomic.incr` and `Atomic.compare_and_set` with and without randomized exponential backoff.

This benchmark is highly CPU dependent.  Here are results from a run my M3 Max with OCaml 5.2:

```sh
➜  multicore-bench git:(add-incr-bench) dune exec --release -- bench/main.exe -budget 1 -brief incr
Atomic incr:                         
  time per op/CAS, 1 domains:
    4.89 ns
  ops over time/CAS, 1 domains:
    204.47 M/s
  time per op/CAS, 2 domains:
    34.43 ns
  ops over time/CAS, 2 domains:
    58.09 M/s
  time per op/CAS, 4 domains:
    160.78 ns
  ops over time/CAS, 4 domains:
    24.88 M/s
  time per op/CAS, 8 domains:
    1267.91 ns
  ops over time/CAS, 8 domains:
    6.33 M/s
  time per op/CAS with backoff, 1 domains:
    4.86 ns
  ops over time/CAS with backoff, 1 domains:
    205.77 M/s
  time per op/CAS with backoff, 2 domains:
    10.09 ns
  ops over time/CAS with backoff, 2 domains:
    198.26 M/s
  time per op/CAS with backoff, 4 domains:
    22.73 ns
  ops over time/CAS with backoff, 4 domains:
    176.00 M/s
  time per op/CAS with backoff, 8 domains:
    55.53 ns
  ops over time/CAS with backoff, 8 domains:
    144.06 M/s
  time per op/Incr, 1 domains:
    1.90 ns
  ops over time/Incr, 1 domains:
    527.59 M/s
  time per op/Incr, 2 domains:
    11.38 ns
  ops over time/Incr, 2 domains:
    175.74 M/s
  time per op/Incr, 4 domains:
    40.06 ns
  ops over time/Incr, 4 domains:
    99.84 M/s
  time per op/Incr, 8 domains:
    349.91 ns
  ops over time/Incr, 8 domains:
    22.86 M/s
```

It is particularly interesting that `Atomic.incr` seems to suffer more from contentention on M3 Max with OCaml 5.2 than CAS with backoff.