### PR TITLE
More careful error handling and finalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+- Improved error handling (@polytypic)
+
 ## 0.1.4
 
 - Automatically filter benchmarks by given diff base file (@polytypic)

--- a/dune-project
+++ b/dune-project
@@ -34,11 +34,9 @@
    (>= 2.1.0))
   (domain_shims
    (>= 0.1.0))
-  ;; Test dependencies
   (backoff
-   (and
-    (>= 0.1.0)
-    :with-test))
+   (>= 0.1.0))
+  ;; Test dependencies
   (mdx
    (and
     (>= 2.4.0)

--- a/lib/barrier.ml
+++ b/lib/barrier.ml
@@ -1,26 +1,62 @@
 (** This barrier is designed to take a single cache line (or word) and to return
     with the participating domains synchronized as precisely as possible. *)
 
-type t = int Atomic.t
+type t = Obj.t Atomic.t
 
 let bits = (Sys.int_size - 1) / 2
 let mask = (1 lsl bits) - 1
 let one = 1 lsl bits
 
-let make total =
+let make total : t =
   if total <= 0 || mask < total then invalid_arg "Barrier: out of bounds";
-  Atomic.make total |> Multicore_magic.copy_as_padded
+  Atomic.make (Obj.repr total) |> Multicore_magic.copy_as_padded
 
-let await t =
-  let state = Atomic.fetch_and_add t one in
+let rec fad (t : t) (n : int) backoff =
+  let before = Atomic.get t in
+  if Obj.is_int before then begin
+    let state = Obj.obj before in
+    let after = Obj.repr (state + n) in
+    if Atomic.compare_and_set t before after then state
+    else fad t n (Backoff.once backoff)
+  end
+  else
+    let exn, bt = Obj.obj before in
+    Printexc.raise_with_backtrace exn bt
+
+let rec set (t : t) (n : int) backoff =
+  let before = Atomic.get t in
+  if Obj.is_int before then begin
+    if not (Atomic.compare_and_set t before (Obj.repr n)) then
+      set t n (Backoff.once backoff)
+  end
+  else
+    let exn, bt = Obj.obj before in
+    Printexc.raise_with_backtrace exn bt
+
+let get (t : t) : int =
+  let before = Atomic.get t in
+  if Obj.is_int before then Obj.obj before
+  else
+    let exn, bt = Obj.obj before in
+    Printexc.raise_with_backtrace exn bt
+
+let await (t : t) =
+  let state = fad t one Backoff.default in
   let total = state land mask in
-  if state lsr bits = total - 1 then Atomic.set t (total - (total lsl bits));
+  if state lsr bits = total - 1 then
+    set t (total - (total lsl bits)) Backoff.default;
 
-  while 0 < Atomic.get t do
+  while 0 < get t do
     Domain.cpu_relax ()
   done;
 
-  Atomic.fetch_and_add t one |> ignore;
-  while Atomic.get t < 0 do
+  fad t one Backoff.default |> ignore;
+  while get t < 0 do
     Domain.cpu_relax ()
   done
+
+let rec poison t exn bt =
+  let before = Atomic.get t in
+  if Obj.is_int before then
+    let after = Obj.repr (exn, bt) in
+    if not (Atomic.compare_and_set t before after) then poison t exn bt

--- a/lib/barrier.mli
+++ b/lib/barrier.mli
@@ -2,3 +2,4 @@ type t
 
 val make : int -> t
 val await : t -> unit
+val poison : t -> exn -> Printexc.raw_backtrace -> unit

--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@ let () =
  (public_name multicore-bench)
  (name multicore_bench)
  (libraries
+  backoff
   multicore-magic
   domain-local-await
   mtime

--- a/lib/finally.ml
+++ b/lib/finally.ml
@@ -1,0 +1,12 @@
+let[@inline never] finally release acquire scope =
+  let x = acquire () in
+  match scope x with
+  | y ->
+      release x;
+      y
+  | exception exn ->
+      let bt = Printexc.get_raw_backtrace () in
+      release x;
+      Printexc.raise_with_backtrace exn bt
+
+external ( let@ ) : ('a -> 'b) -> 'a -> 'b = "%apply"

--- a/multicore-bench.opam
+++ b/multicore-bench.opam
@@ -14,7 +14,7 @@ depends: [
   "mtime" {>= "2.0.0"}
   "yojson" {>= "2.1.0"}
   "domain_shims" {>= "0.1.0"}
-  "backoff" {>= "0.1.0" & with-test}
+  "backoff" {>= "0.1.0"}
   "mdx" {>= "2.4.0" & with-test}
   "sherlodoc" {>= "0.2" & with-doc}
   "odoc" {>= "2.4.1" & with-doc}


### PR DESCRIPTION
Errors raised from benchmark callbacks should now properly stop the timing and backtrace should be preserved.