### PR TITLE
Fail when benchmark results have duplicates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Next version
+
+- Fail when benchmark results have duplicates (@polytypic)
+
 ## 0.1.5
 
 - Improved error handling (@polytypic)

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -30,7 +30,7 @@ module Metric = struct
     >+> fun (name :: value :: units :: trend :: description) ->
     { name; value; units; trend; description }
 
-  let compare_by_name x y = String.compare x.name y.name
+  let name x = x.name
 end
 
 module Benchmark = struct
@@ -41,7 +41,6 @@ module Benchmark = struct
     & Json.prop "metrics" >=> Json.as_list >+> List.filter_map Metric.parse)
     >+> fun (name :: metrics) -> { name; metrics }
 
-  let compare_by_name x y = String.compare x.name y.name
   let name x = x.name
 end
 

--- a/lib/list.ml
+++ b/lib/list.ml
@@ -1,6 +1,27 @@
 include Stdlib.List
 
-let zip_by (type t) (compare : t -> _) xs ys =
-  let (module S) = Set.make compare in
-  let ys = S.of_list ys in
-  xs |> filter_map @@ fun x -> S.find_opt x ys |> Option.map @@ fun y -> (x, y)
+let default_duplicate _ _ = invalid_arg "duplicate key"
+let default_missing _ _ = None
+
+let zip_by (type k) ?(duplicate = default_duplicate)
+    ?(missing = default_missing) (compare : k -> _) key_of xs ys =
+  let (module M) = Map.make compare in
+  let to_map xs =
+    xs
+    |> fold_left
+         (fun m x ->
+           m
+           |> M.update (key_of x) @@ function
+              | None -> Some x
+              | Some y -> duplicate x y)
+         M.empty
+  in
+  M.merge
+    (fun _ x y ->
+      match (x, y) with
+      | Some x, Some y -> Some (x, y)
+      | Some x, None -> missing `R x
+      | None, Some y -> missing `L y
+      | None, None -> None)
+    (to_map xs) (to_map ys)
+  |> M.bindings |> map snd

--- a/lib/map.ml
+++ b/lib/map.ml
@@ -1,5 +1,5 @@
-include Stdlib.Set
+include Stdlib.Map
 
 let make (type t) (compare : t -> _) =
   let (module Elt) = Ordered.make compare in
-  (module Make (Elt) : Stdlib.Set.S with type elt = t)
+  (module Make (Elt) : Stdlib.Map.S with type key = t)

--- a/lib/metric.ml
+++ b/lib/metric.ml
@@ -1,7 +1,9 @@
 type t = Yojson.Safe.t
 
+let a_non_breaking_space = " "
+
 let to_nonbreaking s =
-  s |> String.split_on_char ' ' |> String.concat " " (* a non-breaking space *)
+  s |> String.split_on_char ' ' |> String.concat a_non_breaking_space
 
 let name ~metric ~config = to_nonbreaking (metric ^ "/" ^ config)
 

--- a/lib/ordered.ml
+++ b/lib/ordered.ml
@@ -1,0 +1,7 @@
+let make (type t) (compare : t -> _) =
+  (module struct
+    type nonrec t = t
+
+    let compare = compare
+  end : Stdlib.Set.OrderedType
+    with type t = t)


### PR DESCRIPTION
It is easy to have duplicates in the benchmarks results by mistake and that will cause the results to be treated incorrectly.  This PR makes it so that duplicates in the benchmark results will fail the benchmark executable.