### PR TITLE
Avoid `include` of modules

### DIFF
--- a/lib/cmd.ml
+++ b/lib/cmd.ml
@@ -15,13 +15,13 @@ let duplicate kind name x _ =
        (name x |> replace_non_breaking_spaces))
 
 let print_diff base next =
-  List.zip_by
+  List_ext.zip_by
     ~duplicate:(duplicate "benchmark" Benchmark.name)
     String.compare Benchmark.name base next
   |> List.iter @@ fun ((base : Benchmark.t), (next : Benchmark.t)) ->
      Printf.printf "%s:\n" base.name;
      let zipped =
-       List.zip_by
+       List_ext.zip_by
          ~duplicate:(duplicate "metric" Metric.name)
          String.compare Metric.name base.metrics next.metrics
      in
@@ -159,7 +159,7 @@ let run ~benchmarks ?(budgetf = 0.025) ?(filters = []) ?(debug = false)
          match base_results with
          | [] -> Fun.id
          | results ->
-             let (module S) = Set.make String.compare in
+             let (module S) = Set_ext.make String.compare in
              let names = results |> List.map Benchmark.name |> S.of_list in
              List.filter (fun (name, _) -> S.mem name names)
        end

--- a/lib/countdown.ml
+++ b/lib/countdown.ml
@@ -38,17 +38,17 @@ let non_atomic_set t count =
 
 let rec get t count i =
   if i < Array.length t && Array.unsafe_get t i != Array.unsafe_get t 0 then
-    get t (count + Int.max 0 (Atomic.get (Array.unsafe_get t i))) (i + 1)
+    get t (count + Int_ext.max 0 (Atomic.get (Array.unsafe_get t i))) (i + 1)
   else count
 
-let[@inline] get t = get t (Int.max 0 (Atomic.get (Array.unsafe_get t 0))) 1
+let[@inline] get t = get t (Int_ext.max 0 (Atomic.get (Array.unsafe_get t 0))) 1
 
 let rec alloc t ~batch i =
   if i < Array.length t then
     let c = Array.unsafe_get t i in
     if 0 < Atomic.get c then
       let n = Atomic.fetch_and_add c (-batch) in
-      if 0 < n then Int.min n batch else alloc t ~batch (i + 1)
+      if 0 < n then Int_ext.min n batch else alloc t ~batch (i + 1)
     else alloc t ~batch (i + 1)
   else 0
 
@@ -56,5 +56,5 @@ let[@inline] alloc t ~domain_index ~batch =
   let c = Array.unsafe_get t domain_index in
   if 0 < Atomic.get c then
     let n = Atomic.fetch_and_add c (-batch) in
-    if 0 < n then Int.min n batch else alloc t ~batch 0
+    if 0 < n then Int_ext.min n batch else alloc t ~batch 0
   else alloc t ~batch 0

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -1,4 +1,4 @@
-open Option.Syntax
+open Option_ext.Syntax
 
 module Trend = struct
   type t = [ `Lower_is_better | `Higher_is_better ]

--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,13 @@ let () =
  (enabled_if
   (< %{ocaml_version} 4.13.0))
  (action
-  (copy int.ocaml_4_12.ml int.ml)))
+  (copy int_ext.ocaml_lt_4_13.ml int_ext.ml)))
+
+(rule
+ (enabled_if
+  (>= %{ocaml_version} 4.13.0))
+ (action
+  (copy int_ext.ocaml_ge_4_13.ml int_ext.ml)))
 
 (library
  (public_name multicore-bench)

--- a/lib/int.ocaml_4_12.ml
+++ b/lib/int.ocaml_4_12.ml
@@ -1,4 +1,0 @@
-include Stdlib.Int
-
-let min (x : t) (y : t) = if x < y then x else y
-let max (x : t) (y : t) = if x < y then y else x

--- a/lib/int_ext.ocaml_ge_4_13.ml
+++ b/lib/int_ext.ocaml_ge_4_13.ml
@@ -1,0 +1,2 @@
+let min = Int.min
+let max = Int.max

--- a/lib/int_ext.ocaml_lt_4_13.ml
+++ b/lib/int_ext.ocaml_lt_4_13.ml
@@ -1,0 +1,2 @@
+let min (x : int) (y : int) = if x < y then x else y
+let max (x : int) (y : int) = if x < y then y else x

--- a/lib/json.ml
+++ b/lib/json.ml
@@ -1,4 +1,4 @@
-open Option.Syntax
+open Option_ext.Syntax
 
 type t = Yojson.Safe.t
 

--- a/lib/list_ext.ml
+++ b/lib/list_ext.ml
@@ -1,14 +1,12 @@
-include Stdlib.List
-
 let default_duplicate _ _ = invalid_arg "duplicate key"
 let default_missing _ _ = None
 
 let zip_by (type k) ?(duplicate = default_duplicate)
     ?(missing = default_missing) (compare : k -> _) key_of xs ys =
-  let (module M) = Map.make compare in
+  let (module M) = Map_ext.make compare in
   let to_map xs =
     xs
-    |> fold_left
+    |> List.fold_left
          (fun m x ->
            m
            |> M.update (key_of x) @@ function
@@ -24,4 +22,4 @@ let zip_by (type k) ?(duplicate = default_duplicate)
       | None, Some y -> missing `L y
       | None, None -> None)
     (to_map xs) (to_map ys)
-  |> M.bindings |> map snd
+  |> M.bindings |> List.map snd

--- a/lib/map_ext.ml
+++ b/lib/map_ext.ml
@@ -1,5 +1,3 @@
-include Stdlib.Set
-
 let make (type t) (compare : t -> _) =
   let (module Elt) = Ordered.make compare in
-  (module Make (Elt) : Stdlib.Set.S with type elt = t)
+  (module Map.Make (Elt) : Map.S with type key = t)

--- a/lib/option_ext.ml
+++ b/lib/option_ext.ml
@@ -1,5 +1,3 @@
-include Stdlib.Option
-
 let pair x y = match (x, y) with Some x, Some y -> Some (x, y) | _ -> None
 
 module Syntax = struct
@@ -10,13 +8,13 @@ module Syntax = struct
         match r x with None -> None | Some r -> Some Infix_pair.(l :: r)
       end
 
-  let ( let* ) = bind
-  let ( >>= ) = bind
+  let ( let* ) = Option.bind
+  let ( >>= ) = Option.bind
   let ( >=> ) f g x = f x >>= g
-  let ( let+ ) x f = map f x
+  let ( let+ ) x f = Option.map f x
   let ( >>+ ) = ( let+ )
   let ( >+> ) f g x = f x >>+ g
-  let pure = some
+  let pure = Option.some
   let ( and* ) = pair
   let ( and+ ) = pair
 end

--- a/lib/ordered.ml
+++ b/lib/ordered.ml
@@ -3,5 +3,5 @@ let make (type t) (compare : t -> _) =
     type nonrec t = t
 
     let compare = compare
-  end : Stdlib.Set.OrderedType
+  end : Set.OrderedType
     with type t = t)

--- a/lib/set_ext.ml
+++ b/lib/set_ext.ml
@@ -1,5 +1,3 @@
-include Stdlib.Map
-
 let make (type t) (compare : t -> _) =
   let (module Elt) = Ordered.make compare in
-  (module Make (Elt) : Stdlib.Map.S with type key = t)
+  (module Set.Make (Elt) : Set.S with type elt = t)

--- a/lib/times.ml
+++ b/lib/times.ml
@@ -65,7 +65,7 @@ let record (type a) ~budgetf ~n_domains ?(ensure_multi_domain = true)
       wrap;
       results =
         Array.init n_domains (fun _ ->
-            Float.Array.create (Int.max n_runs_min n_runs_max));
+            Float.Array.create (Int_ext.max n_runs_min n_runs_max));
       budget_start = Mtime_clock.elapsed ();
       before;
       init;

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -8,7 +8,7 @@ let rec alloc ?(batch = 1000) counter =
   let n = Atomic.get counter in
   if n = 0 then 0
   else
-    let batch = Int.min n batch in
+    let batch = Int_ext.min n batch in
     if Atomic.compare_and_set counter n (n - batch) then batch
     else alloc ~batch counter
 


### PR DESCRIPTION
`include` of modules generates massive amounts of code with the native OCaml compiler.